### PR TITLE
fix: Remove subscription UI elements from navigation and profile

### DIFF
--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -22,7 +22,6 @@ import {
   Dashboard as DashboardIcon,
   CalendarToday as CalendarIcon,
   School as SchoolIcon,
-  Star as StarIcon,
   Person as PersonIcon,
   Logout as LogoutIcon,
   Notifications as NotificationsIcon,
@@ -39,7 +38,6 @@ const menuItems = [
   { text: 'Dashboard', icon: <DashboardIcon />, path: '/' },
   { text: 'Calendario', icon: <CalendarIcon />, path: '/calendar' },
   { text: 'Cursos', icon: <SchoolIcon />, path: '/courses' },
-  { text: 'Suscripción', icon: <StarIcon />, path: '/subscription' },
   { text: 'Perfil', icon: <PersonIcon />, path: '/profile' },
 ];
 

--- a/src/components/profile/UserProfile.tsx
+++ b/src/components/profile/UserProfile.tsx
@@ -10,7 +10,6 @@ import {
   Button,
   Tabs,
   Tab,
-  Chip,
   List,
   ListItem,
   ListItemText,
@@ -143,20 +142,10 @@ export default function UserProfile() {
             </CardContent>
           </Card>
 
-          {/* Suscripción */}
+          {/* Cambiar Contraseña */}
           <Card>
             <CardContent>
               <Typography variant="h6" gutterBottom sx={{ fontWeight: 600 }}>
-                Suscripción Actual
-              </Typography>
-              
-              <Chip
-                label="Plan Gratuito"
-                color="primary"
-                sx={{ mb: 2 }}
-              />
-              
-              <Typography variant="h6" gutterBottom sx={{ fontWeight: 600, mt: 3 }}>
                 Cambiar Contraseña
               </Typography>
               


### PR DESCRIPTION
- Remove 'Suscripción' menu item from DashboardLayout navigation
- Remove StarIcon import (no longer needed)
- Remove subscription section from UserProfile component
- Remove Chip import (no longer used)
- UI is now fully subscription-free for open source version