### PR TITLE
feat: implementar landing page con modals de bienvenida y registro

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,21 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  experimental: {
-    turbo: {
-      resolveExtensions: [
-        ".mdx",
-        ".tsx",
-        ".ts",
-        ".jsx",
-        ".js",
-        ".mjs",
-        ".json",
-      ],
-    },
+  turbopack: {
+    resolveExtensions: [".mdx", ".tsx", ".ts", ".jsx", ".js", ".mjs", ".json"],
   },
-  // Temporarily disable font optimization in dev
-  optimizeFonts: process.env.NODE_ENV === "production",
 };
 
 export default nextConfig;

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,10 @@
+import DashboardLayout from '../../components/layout/DashboardLayout';
+import Dashboard from '../../components/dashboard/Dashboard';
+
+export default function DashboardPage() {
+  return (
+    <DashboardLayout>
+      <Dashboard />
+    </DashboardLayout>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,5 @@
-import DashboardLayout from '../components/layout/DashboardLayout';
-import Dashboard from '../components/dashboard/Dashboard';
+import LandingPage from '../components/landing/LandingPage';
 
-export default async function Home() {
-  
-  return (
-    <DashboardLayout>
-      <Dashboard />
-    </DashboardLayout>
-  );
+export default function Home() {
+  return <LandingPage />;
 }

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+"use client";
+
+import React, { useState } from 'react';
+import { 
+  Box, 
+  Typography, 
+  Button, 
+  AppBar, 
+  Toolbar, 
+  Container,
+  Stack,
+  Card,
+  CardContent
+} from '@mui/material';
+import Link from 'next/link';
+import { School, CalendarToday, Assessment } from '@mui/icons-material';
+import WelcomeModal from '../modals/welcome/WelcomeModal';
+import { WelcomeFormData } from '../modals/welcome/types';
+import RegistrationModal from '../modals/registration/RegistrationModal';
+import { RegistrationFormData } from '../modals/registration/types';
+
+export default function LandingPage() {
+  const [welcomeModalOpen, setWelcomeModalOpen] = useState(false);
+  const [registrationModalOpen, setRegistrationModalOpen] = useState(false);
+  const [welcomeData, setWelcomeData] = useState<WelcomeFormData | null>(null);
+
+  const handleWelcomeComplete = (data: WelcomeFormData) => {
+    setWelcomeData(data);
+    setWelcomeModalOpen(false);
+    setRegistrationModalOpen(true);
+  };
+
+  const handleRegistration = (data: RegistrationFormData) => {
+    // Aquí enviarías los datos a tu backend de AWS
+    console.log('Datos completos del usuario:', data);
+    
+    // Cerrar modales y resetear
+    setRegistrationModalOpen(false);
+    setWelcomeData(null);
+    
+    // Aquí podrías redirigir al dashboard o mostrar un mensaje de éxito
+    alert('¡Registro completado con éxito!');
+  };
+
+  const openWelcomeModal = () => {
+    setWelcomeModalOpen(true);
+  };
+  return (
+    <Box>
+      {/* Navbar */}
+      <AppBar position="static" sx={{ backgroundColor: '#1976d2' }}>
+        <Container maxWidth="lg">
+          <Toolbar>
+            <Typography variant="h6" component="div" sx={{ flexGrow: 1, fontWeight: 'bold' }}>
+              PrioSync
+            </Typography>
+            <Stack direction="row" spacing={3} sx={{ mr: 2 }}>
+              <Link href="#inicio" style={{ color: 'white', textDecoration: 'none' }}>
+                Inicio
+              </Link>
+              <Link href="#funcionalidades" style={{ color: 'white', textDecoration: 'none' }}>
+                Funcionalidades
+              </Link>
+              <Link href="#contacto" style={{ color: 'white', textDecoration: 'none' }}>
+                Contacto
+              </Link>
+            </Stack>
+            <Button 
+              variant="outlined" 
+              sx={{ color: 'white', borderColor: 'white', mr: 1 }}
+            >
+              Iniciar Sesión
+            </Button>
+            <Link href="/dashboard" passHref>
+              <Button 
+                variant="contained" 
+                sx={{ backgroundColor: 'white', color: '#1976d2' }}
+              >
+                Dashboard
+              </Button>
+            </Link>
+          </Toolbar>
+        </Container>
+      </AppBar>
+
+      {/* Hero Section */}
+      <Box 
+        id="inicio"
+        sx={{ 
+          background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+          py: 8,
+          color: 'white',
+          textAlign: 'center'
+        }}
+      >
+        <Container maxWidth="lg">
+          <Typography variant="h2" component="h1" gutterBottom sx={{ fontWeight: 'bold' }}>
+            ¡Bienvenido a PrioSync!
+          </Typography>
+          <Typography variant="h5" sx={{ mb: 4, opacity: 0.9 }}>
+            La plataforma integral para la gestión académica moderna
+          </Typography>
+          <Typography variant="body1" sx={{ mb: 4, fontSize: '1.2rem', maxWidth: '600px', mx: 'auto' }}>
+            Organiza tus estudios, gestiona tus horarios y mantente al día con tus evaluaciones 
+            en una sola plataforma intuitiva y eficiente.
+          </Typography>
+          <Button 
+            variant="contained" 
+            size="large" 
+            onClick={openWelcomeModal}
+            sx={{ backgroundColor: 'white', color: '#667eea', py: 1.5, px: 4 }}
+          >
+            Comenzar Ahora
+          </Button>
+        </Container>
+      </Box>
+
+      {/* Features Section */}
+      <Box id="funcionalidades" sx={{ py: 8, backgroundColor: '#f5f5f5' }}>
+        <Container maxWidth="lg">
+          <Typography variant="h3" component="h2" gutterBottom textAlign="center" sx={{ mb: 6, color: '#333' }}>
+            Funcionalidades Principales
+          </Typography>
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={4}>
+            <Card sx={{ flex: 1, textAlign: 'center', p: 2 }}>
+              <CardContent>
+                <CalendarToday sx={{ fontSize: 60, color: '#1976d2', mb: 2 }} />
+                <Typography variant="h5" component="h3" gutterBottom>
+                  Gestión de Horarios
+                </Typography>
+                <Typography variant="body1">
+                  Organiza tu calendario académico con facilidad. Programa clases, 
+                  estudios y actividades extracurriculares en una interfaz intuitiva.
+                </Typography>
+              </CardContent>
+            </Card>
+
+            <Card sx={{ flex: 1, textAlign: 'center', p: 2 }}>
+              <CardContent>
+                <School sx={{ fontSize: 60, color: '#1976d2', mb: 2 }} />
+                <Typography variant="h5" component="h3" gutterBottom>
+                  Seguimiento Académico
+                </Typography>
+                <Typography variant="body1">
+                  Mantén un registro detallado de tus materias, notas y progreso académico. 
+                  Visualiza tu rendimiento con gráficos y estadísticas.
+                </Typography>
+              </CardContent>
+            </Card>
+
+            <Card sx={{ flex: 1, textAlign: 'center', p: 2 }}>
+              <CardContent>
+                <Assessment sx={{ fontSize: 60, color: '#1976d2', mb: 2 }} />
+                <Typography variant="h5" component="h3" gutterBottom>
+                  Control de Evaluaciones
+                </Typography>
+                <Typography variant="body1">
+                  No te pierdas ninguna evaluación importante. Recibe recordatorios 
+                  y organiza tu tiempo de estudio de manera efectiva.
+                </Typography>
+              </CardContent>
+            </Card>
+          </Stack>
+        </Container>
+      </Box>
+
+      {/* Footer */}
+      <Box id="contacto" sx={{ backgroundColor: '#1976d2', color: 'white', py: 2 }}>
+        <Container maxWidth="lg">
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={4} justifyContent="space-between">
+            <Box>
+              <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+                PrioSync
+              </Typography>
+              <Typography variant="body2">
+                Tu compañero ideal para el éxito académico
+              </Typography>
+            </Box>
+            <Box>
+              <Typography variant="h6" gutterBottom>
+                Enlaces Rápidos
+              </Typography>
+              <Stack spacing={1}>
+                <Link href="#inicio" style={{ color: 'white', textDecoration: 'none' }}>
+                  Inicio
+                </Link>
+                <Link href="#funcionalidades" style={{ color: 'white', textDecoration: 'none' }}>
+                  Funcionalidades
+                </Link>
+                <Link href="/dashboard" style={{ color: 'white', textDecoration: 'none' }}>
+                  Dashboard
+                </Link>
+              </Stack>
+            </Box>
+            <Box>
+              <Typography variant="h6" gutterBottom>
+                Contacto
+              </Typography>
+              <Typography variant="body2">
+                Email: info@priosync.com
+              </Typography>
+              <Typography variant="body2">
+                Teléfono: +56 9 1234 5678
+              </Typography>
+            </Box>
+          </Stack>
+          <Box sx={{ borderTop: '1px solid #555', mt: 2, pt: 1.5, textAlign: 'center' }}>
+            <Typography variant="body2">
+              © 2024 PrioSync. Todos los derechos reservados.
+            </Typography>
+          </Box>
+        </Container>
+      </Box>
+
+      {/* Modales */}
+      <WelcomeModal
+        open={welcomeModalOpen}
+        onClose={() => setWelcomeModalOpen(false)}
+        onComplete={handleWelcomeComplete}
+      />
+
+      <RegistrationModal
+        open={registrationModalOpen}
+        onClose={() => setRegistrationModalOpen(false)}
+        welcomeData={welcomeData || undefined}
+        onRegister={handleRegistration}
+      />
+    </Box>
+  );
+}

--- a/src/components/modals/registration/RegistrationForm.tsx
+++ b/src/components/modals/registration/RegistrationForm.tsx
@@ -1,0 +1,246 @@
+import React from 'react';
+import { TextField, InputAdornment, Stack } from '@mui/material';
+import { Person, Person2, Phone, Email, Lock } from '@mui/icons-material';
+
+interface RegistrationFormProps {
+  formData: {
+    nombre: string;
+    apellido: string;
+    telefono: string;
+    email: string;
+    password: string;
+    confirmPassword: string;
+  };
+  errors: {
+    nombre: boolean;
+    apellido: boolean;
+    telefono: boolean;
+    email: boolean;
+    password: boolean;
+    confirmPassword: boolean;
+  };
+  loading: boolean;
+  onNombreChange: (value: string) => void;
+  onApellidoChange: (value: string) => void;
+  onTelefonoChange: (value: string) => void;
+  onEmailChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+  onConfirmPasswordChange: (value: string) => void;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+}
+
+export default function RegistrationForm({
+  formData,
+  errors,
+  loading,
+  onNombreChange,
+  onApellidoChange,
+  onTelefonoChange,
+  onEmailChange,
+  onPasswordChange,
+  onConfirmPasswordChange,
+  onSubmit
+}: RegistrationFormProps) {
+  return (
+    <form id="registration-form" onSubmit={onSubmit}>
+      <Stack spacing={2}>
+        <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+          <TextField
+            fullWidth
+            label="Nombre"
+            type="text"
+            value={formData.nombre}
+            onChange={(e) => onNombreChange(e.target.value)}
+            placeholder="Tu nombre"
+            disabled={loading}
+            error={errors.nombre}
+            required
+            autoComplete="given-name"
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Person color="action" />
+                </InputAdornment>
+              ),
+            }}
+            sx={{
+              '& .MuiOutlinedInput-root': {
+                borderRadius: 2,
+                backgroundColor: '#fafafa',
+                '&:hover': {
+                  backgroundColor: '#ffffff',
+                },
+                '&.Mui-focused': {
+                  backgroundColor: '#ffffff',
+                },
+              },
+            }}
+          />
+
+          <TextField
+            fullWidth
+            label="Apellido"
+            type="text"
+            value={formData.apellido}
+            onChange={(e) => onApellidoChange(e.target.value)}
+            placeholder="Tu apellido"
+            disabled={loading}
+            error={errors.apellido}
+            required
+            autoComplete="family-name"
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Person2 color="action" />
+                </InputAdornment>
+              ),
+            }}
+            sx={{
+              '& .MuiOutlinedInput-root': {
+                borderRadius: 2,
+                backgroundColor: '#fafafa',
+                '&:hover': {
+                  backgroundColor: '#ffffff',
+                },
+                '&.Mui-focused': {
+                  backgroundColor: '#ffffff',
+                },
+              },
+            }}
+          />
+        </Stack>
+
+        <TextField
+          fullWidth
+          label="Teléfono móvil"
+          type="tel"
+          value={formData.telefono}
+          onChange={(e) => onTelefonoChange(e.target.value)}
+          placeholder="+56912345678"
+          disabled={loading}
+          error={errors.telefono}
+          required
+          autoComplete="tel"
+          helperText="Formato: +56912345678"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Phone color="action" />
+              </InputAdornment>
+            ),
+          }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              borderRadius: 2,
+              backgroundColor: '#fafafa',
+              '&:hover': {
+                backgroundColor: '#ffffff',
+              },
+              '&.Mui-focused': {
+                backgroundColor: '#ffffff',
+              },
+            },
+          }}
+        />
+
+        <TextField
+          fullWidth
+          label="Correo electrónico"
+          type="email"
+          value={formData.email}
+          onChange={(e) => onEmailChange(e.target.value)}
+          placeholder="tu@email.com"
+          disabled={loading}
+          error={errors.email}
+          required
+          autoComplete="email"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Email color="action" />
+              </InputAdornment>
+            ),
+          }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              borderRadius: 2,
+              backgroundColor: '#fafafa',
+              '&:hover': {
+                backgroundColor: '#ffffff',
+              },
+              '&.Mui-focused': {
+                backgroundColor: '#ffffff',
+              },
+            },
+          }}
+        />
+
+        <TextField
+          fullWidth
+          label="Contraseña"
+          type="password"
+          value={formData.password}
+          onChange={(e) => onPasswordChange(e.target.value)}
+          placeholder="••••••••"
+          disabled={loading}
+          error={errors.password}
+          required
+          autoComplete="new-password"
+          helperText="Mínimo 8 caracteres, con mayúscula, minúscula y número"
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <Lock color="action" />
+              </InputAdornment>
+            ),
+          }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+            borderRadius: 2,
+            backgroundColor: '#fafafa',
+            '&:hover': {
+              backgroundColor: '#ffffff',
+            },
+            '&.Mui-focused': {
+              backgroundColor: '#ffffff',
+            },
+          },
+        }}
+      />
+
+      <TextField
+        fullWidth
+        label="Confirmar contraseña"
+        type="password"
+        value={formData.confirmPassword}
+        onChange={(e) => onConfirmPasswordChange(e.target.value)}
+        placeholder="••••••••"
+        disabled={loading}
+        error={errors.confirmPassword}
+        required
+        autoComplete="new-password"
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Lock color="action" />
+            </InputAdornment>
+          ),
+        }}
+        sx={{
+          mb: 3,
+          '& .MuiOutlinedInput-root': {
+            borderRadius: 2,
+            backgroundColor: '#fafafa',
+            '&:hover': {
+              backgroundColor: '#ffffff',
+            },
+            '&.Mui-focused': {
+              backgroundColor: '#ffffff',
+            },
+          },
+        }}
+      />
+      </Stack>
+    </form>
+  );
+}

--- a/src/components/modals/registration/RegistrationModal.tsx
+++ b/src/components/modals/registration/RegistrationModal.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import React, { useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  Typography,
+  Alert,
+  CircularProgress,
+} from '@mui/material';
+import {
+  PersonAdd,
+  CheckCircle,
+  Error,
+} from '@mui/icons-material';
+import WelcomeSummary from './WelcomeSummary';
+import RegistrationForm from './RegistrationForm';
+import { 
+  RegistrationFormData,
+  RegistrationFormFields,
+  ERROR_MESSAGES, 
+  validateEmail, 
+  validatePassword,
+  validateChileanPhone,
+  validateName
+} from './types';
+import { WelcomeFormData } from '../welcome/types';
+
+interface RegistrationModalProps {
+  open: boolean;
+  onClose: () => void;
+  welcomeData?: WelcomeFormData;
+  onRegister: (data: RegistrationFormData) => void;
+}
+
+export default function RegistrationModal({ open, onClose, welcomeData, onRegister }: RegistrationModalProps) {
+  const [formData, setFormData] = useState<RegistrationFormFields>(() => {
+    // Cargar datos persistentes del localStorage si existen
+    if (typeof window !== 'undefined') {
+      const savedData = localStorage.getItem('registrationFormData');
+      if (savedData) {
+        return JSON.parse(savedData) as RegistrationFormFields;
+      }
+    }
+    return {
+      nombre: '',
+      apellido: '',
+      telefono: '',
+      email: '',
+      password: '',
+      confirmPassword: ''
+    };
+  });
+  const [errors, setErrors] = useState({
+    nombre: false,
+    apellido: false,
+    telefono: false,
+    email: false,
+    password: false,
+    confirmPassword: false
+  });
+  const [localError, setLocalError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  // Persistencia: guardar datos en localStorage cada vez que cambien
+  React.useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('registrationFormData', JSON.stringify(formData));
+    }
+  }, [formData]);
+
+  // Limpiar formulario
+  const clearForm = () => {
+    const initialFormData: RegistrationFormFields = {
+      nombre: '',
+      apellido: '',
+      telefono: '',
+      email: '',
+      password: '',
+      confirmPassword: ''
+    };
+    setFormData(initialFormData);
+    setErrors({
+      nombre: false,
+      apellido: false,
+      telefono: false,
+      email: false,
+      password: false,
+      confirmPassword: false
+    });
+    setLocalError('');
+    setLoading(false);
+    setSuccess(false);
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('registrationFormData');
+    }
+  };
+
+  // Manejar cancelar: cerrar modal y limpiar formulario
+  const handleCancel = () => {
+    clearForm();
+    onClose();
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLocalError('');
+    setErrors({ 
+      nombre: false, 
+      apellido: false, 
+      telefono: false, 
+      email: false, 
+      password: false, 
+      confirmPassword: false 
+    });
+
+    // Validar nombre
+    if (!validateName(formData.nombre)) {
+      setLocalError(ERROR_MESSAGES.INVALID_NAME);
+      setErrors(prev => ({ ...prev, nombre: true }));
+      return;
+    }
+
+    // Validar apellido
+    if (!validateName(formData.apellido)) {
+      setLocalError(ERROR_MESSAGES.INVALID_LASTNAME);
+      setErrors(prev => ({ ...prev, apellido: true }));
+      return;
+    }
+
+    // Validar teléfono
+    if (!validateChileanPhone(formData.telefono)) {
+      setLocalError(ERROR_MESSAGES.INVALID_PHONE);
+      setErrors(prev => ({ ...prev, telefono: true }));
+      return;
+    }
+
+    // Validar email
+    if (!formData.email || !validateEmail(formData.email)) {
+      setLocalError(ERROR_MESSAGES.INVALID_EMAIL);
+      setErrors(prev => ({ ...prev, email: true }));
+      return;
+    }
+
+    // Validar contraseña
+    const passwordValidation = validatePassword(formData.password);
+    if (!passwordValidation.isValid) {
+      setLocalError(passwordValidation.message || ERROR_MESSAGES.PASSWORD_WEAK);
+      setErrors(prev => ({ ...prev, password: true }));
+      return;
+    }
+
+    // Validar confirmación de contraseña
+    if (formData.password !== formData.confirmPassword) {
+      setLocalError(ERROR_MESSAGES.PASSWORDS_DONT_MATCH);
+      setErrors(prev => ({ ...prev, confirmPassword: true }));
+      return;
+    }
+
+    // Simular proceso de registro
+    setLoading(true);
+    
+    try {
+      // Aquí llamarías a tu servicio de AWS
+      const registrationData: RegistrationFormData = {
+        ...formData,
+        welcomeData
+      };
+      
+      // Simular delay de API
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      
+      onRegister(registrationData);
+      setSuccess(true);
+      
+      // Cerrar modal después del éxito y limpiar datos
+      setTimeout(() => {
+        clearForm();
+        onClose();
+      }, 2000);
+      
+    } catch {
+      setLocalError(ERROR_MESSAGES.REGISTRATION_FAILED);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const clearErrors = () => {
+    setLocalError('');
+    setErrors({ 
+      nombre: false, 
+      apellido: false, 
+      telefono: false, 
+      email: false, 
+      password: false, 
+      confirmPassword: false 
+    });
+  };
+
+  const handleNombreChange = (value: string) => {
+    setFormData((prev: RegistrationFormFields) => ({ ...prev, nombre: value }));
+    if (localError || errors.nombre) clearErrors();
+  };
+
+  const handleApellidoChange = (value: string) => {
+    setFormData((prev: RegistrationFormFields) => ({ ...prev, apellido: value }));
+    if (localError || errors.apellido) clearErrors();
+  };
+
+  const handleTelefonoChange = (value: string) => {
+    setFormData((prev: RegistrationFormFields) => ({ ...prev, telefono: value }));
+    if (localError || errors.telefono) clearErrors();
+  };
+
+  const handleEmailChange = (value: string) => {
+    setFormData((prev: RegistrationFormFields) => ({ ...prev, email: value }));
+    if (localError || errors.email) clearErrors();
+  };
+
+  const handlePasswordChange = (value: string) => {
+    setFormData((prev: RegistrationFormFields) => ({ ...prev, password: value }));
+    if (localError || errors.password) clearErrors();
+  };
+
+  const handleConfirmPasswordChange = (value: string) => {
+    setFormData((prev: RegistrationFormFields) => ({ ...prev, confirmPassword: value }));
+    if (localError || errors.confirmPassword) clearErrors();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => {}} // Desactivar cierre al hacer clic fuera
+      disableEscapeKeyDown // Desactivar cierre con tecla Escape
+      maxWidth="sm"
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: 3,
+          boxShadow: '0 8px 32px rgba(0,0,0,0.1)',
+        }
+      }}
+    >
+      <DialogTitle sx={{ textAlign: 'center', pb: 2 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 2,
+            mb: 2,
+          }}
+        >
+          <Box
+            sx={{
+              background: 'linear-gradient(135deg, #1976d2 0%, #1565c0 100%)',
+              color: 'white',
+              width: 48,
+              height: 48,
+              borderRadius: 2,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <PersonAdd fontSize="large" />
+          </Box>
+          <Typography
+            variant="h4"
+            component="div"
+            sx={{
+              fontWeight: 500,
+              color: '#1976d2',
+            }}
+          >
+            PrioSync
+          </Typography>
+        </Box>
+        
+        <Typography
+          variant="h5"
+          component="div"
+          sx={{
+            fontWeight: 300,
+            color: '#212121',
+            mb: 1,
+          }}
+        >
+          Crear Nueva Cuenta
+        </Typography>
+        
+        <Typography
+          variant="body1"
+          sx={{
+            color: '#757575',
+            lineHeight: 1.5,
+          }}
+        >
+          {welcomeData ? `¡Hola ${welcomeData.nombre}!` : ''} Completa el registro para comenzar
+        </Typography>
+      </DialogTitle>
+
+      <DialogContent sx={{ px: 4, pb: 2 }}>
+        {/* Resumen de datos de bienvenida */}
+        {welcomeData && <WelcomeSummary welcomeData={welcomeData} />}
+
+        {/* Mensajes de estado */}
+        {localError && (
+          <Alert
+            severity="error"
+            icon={<Error />}
+            sx={{ mb: 2 }}
+            onClose={() => setLocalError('')}
+          >
+            {localError}
+          </Alert>
+        )}
+
+        {success && (
+          <Alert
+            severity="success"
+            icon={<CheckCircle />}
+            sx={{ mb: 2 }}
+          >
+            ¡Cuenta creada exitosamente! Redirigiendo...
+          </Alert>
+        )}
+
+        {/* Formulario */}
+        <RegistrationForm
+          formData={formData}
+          errors={errors}
+          loading={loading}
+          onNombreChange={handleNombreChange}
+          onApellidoChange={handleApellidoChange}
+          onTelefonoChange={handleTelefonoChange}
+          onEmailChange={handleEmailChange}
+          onPasswordChange={handlePasswordChange}
+          onConfirmPasswordChange={handleConfirmPasswordChange}
+          onSubmit={handleSubmit}
+        />
+      </DialogContent>
+
+      <DialogActions sx={{ px: 4, pb: 3 }}>
+        <Button
+          onClick={handleCancel}
+          variant="outlined"
+          disabled={loading}
+          sx={{ borderRadius: 2 }}
+        >
+          Cancelar
+        </Button>
+        
+        <Button
+          type="submit"
+          form="registration-form"
+          variant="contained"
+          disabled={loading}
+          startIcon={loading ? <CircularProgress size={20} /> : <PersonAdd />}
+          sx={{
+            borderRadius: 2,
+            background: 'linear-gradient(135deg, #1976d2 0%, #1565c0 100%)',
+            '&:hover': {
+              background: 'linear-gradient(135deg, #1565c0 0%, #0d47a1 100%)',
+              transform: 'translateY(-2px)',
+              boxShadow: '0 4px 12px rgba(25, 118, 210, 0.3)',
+            },
+            '&:disabled': {
+              background: '#e0e0e0',
+              color: '#9e9e9e',
+            },
+          }}
+        >
+          {loading ? 'Creando Cuenta...' : 'Crear Cuenta'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/modals/registration/WelcomeSummary.tsx
+++ b/src/components/modals/registration/WelcomeSummary.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+import { WelcomeFormData, DaySchedule } from '../welcome/types';
+
+interface WelcomeSummaryProps {
+  welcomeData: WelcomeFormData;
+}
+
+const formatSchedule = (schedule: DaySchedule[]): string => {
+  if (schedule.length === 0) return 'Sin horarios definidos';
+  
+  return schedule
+    .filter(day => day.timeSlots.length > 0)
+    .map(day => {
+      const slots = day.timeSlots.map(slot => `${slot.start}-${slot.end}`).join(', ');
+      return `${day.day}: ${slots}`;
+    })
+    .join('; ');
+};
+
+export default function WelcomeSummary({ welcomeData }: WelcomeSummaryProps) {
+  return (
+    <Box sx={{ mb: 3, p: 2, backgroundColor: '#f5f5f5', borderRadius: 2 }}>
+      <Typography variant="subtitle2" color="primary" gutterBottom>
+        Resumen de tu perfil:
+      </Typography>
+      <Typography variant="body2" sx={{ mb: 0.5 }}>
+        📚 Estudiar: {welcomeData.estudio}
+      </Typography>
+      <Typography variant="body2" sx={{ mb: 0.5 }}>
+        ⏰ Tiempo: {formatSchedule(welcomeData.tiempoDisponible)}
+      </Typography>
+      <Typography variant="body2">
+        🎥 YouTube: {welcomeData.youtubeUrl}
+      </Typography>
+    </Box>
+  );
+}

--- a/src/components/modals/registration/types.ts
+++ b/src/components/modals/registration/types.ts
@@ -1,0 +1,80 @@
+import { WelcomeFormData } from "../welcome/types";
+
+export interface RegistrationFormFields {
+  nombre: string;
+  apellido: string;
+  telefono: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+}
+
+export interface RegistrationFormData {
+  nombre: string;
+  apellido: string;
+  telefono: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+  welcomeData?: WelcomeFormData;
+}
+
+// Configuración de validación
+export const VALIDATION_CONFIG = {
+  PASSWORD_MIN_LENGTH: 8,
+  EMAIL_REQUIRED: true,
+  PASSWORD_REQUIRED: true,
+} as const;
+
+// Mensajes de error
+export const ERROR_MESSAGES = {
+  INVALID_NAME: "Por favor ingresa tu nombre",
+  INVALID_LASTNAME: "Por favor ingresa tu apellido",
+  INVALID_PHONE:
+    "Por favor ingresa un número de teléfono chileno válido (ej: +56912345678)",
+  INVALID_EMAIL: "Por favor ingresa un correo electrónico válido",
+  PASSWORD_TOO_SHORT: `La contraseña debe tener al menos ${VALIDATION_CONFIG.PASSWORD_MIN_LENGTH} caracteres`,
+  PASSWORD_WEAK:
+    "La contraseña debe contener al menos una letra mayúscula, una minúscula y un número",
+  PASSWORDS_DONT_MATCH: "Las contraseñas no coinciden",
+  REGISTRATION_FAILED: "Error al crear la cuenta. Inténtalo de nuevo.",
+} as const;
+
+export const validateEmail = (email: string): boolean => {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+};
+
+export const validatePassword = (
+  password: string
+): { isValid: boolean; message?: string } => {
+  if (password.length < VALIDATION_CONFIG.PASSWORD_MIN_LENGTH) {
+    return {
+      isValid: false,
+      message: ERROR_MESSAGES.PASSWORD_TOO_SHORT,
+    };
+  }
+
+  const hasUpperCase = /[A-Z]/.test(password);
+  const hasLowerCase = /[a-z]/.test(password);
+  const hasNumbers = /\d/.test(password);
+
+  if (!hasUpperCase || !hasLowerCase || !hasNumbers) {
+    return {
+      isValid: false,
+      message: ERROR_MESSAGES.PASSWORD_WEAK,
+    };
+  }
+
+  return { isValid: true };
+};
+
+export const validateChileanPhone = (phone: string): boolean => {
+  // Formato: +56912345678 (móvil chileno)
+  const phoneRegex = /^\+569[0-9]{8}$/;
+  return phoneRegex.test(phone);
+};
+
+export const validateName = (name: string): boolean => {
+  return name.trim().length >= 2;
+};

--- a/src/components/modals/welcome/NameStep.tsx
+++ b/src/components/modals/welcome/NameStep.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  TextField,
+  InputAdornment
+} from '@mui/material';
+import { Person } from '@mui/icons-material';
+
+interface NameStepProps {
+  nombre: string;
+  onChange: (value: string) => void;
+  error: boolean;
+}
+
+export default function NameStep({ nombre, onChange, error }: NameStepProps) {
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom sx={{ color: '#1976d2', mb: 3 }}>
+        ¡Hola! Empecemos conociéndote mejor
+      </Typography>
+      <TextField
+        fullWidth
+        label="¿Cuál es tu nombre?"
+        value={nombre}
+        onChange={(e) => onChange(e.target.value)}
+        error={error}
+        helperText={error ? 'Por favor ingresa tu nombre' : ''}
+        placeholder="Escribe tu nombre aquí"
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <Person color="action" />
+            </InputAdornment>
+          ),
+        }}
+        sx={{
+          '& .MuiOutlinedInput-root': {
+            borderRadius: 2,
+          },
+        }}
+      />
+    </Box>
+  );
+}

--- a/src/components/modals/welcome/ScheduleStep.tsx
+++ b/src/components/modals/welcome/ScheduleStep.tsx
@@ -1,0 +1,237 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Typography,
+  Card,
+  CardContent,
+  Chip,
+  Button,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Stack,
+  Paper
+} from '@mui/material';
+import { Schedule, AccessTime, Add, Delete } from '@mui/icons-material';
+import { DaySchedule, TimeSlot, daysOfWeek, timeSlots } from './types';
+
+interface ScheduleStepProps {
+  schedule: DaySchedule[];
+  onChange: (schedule: DaySchedule[]) => void;
+  error: boolean;
+}
+
+export default function ScheduleStep({ schedule, onChange, error }: ScheduleStepProps) {
+  const [selectedDay, setSelectedDay] = useState('');
+  const [startTime, setStartTime] = useState('');
+  const [endTime, setEndTime] = useState('');
+
+  const addTimeSlot = () => {
+    if (!selectedDay || !startTime || !endTime) return;
+    
+    if (startTime >= endTime) {
+      alert('La hora de inicio debe ser anterior a la hora de fin');
+      return;
+    }
+
+    const newTimeSlot: TimeSlot = { start: startTime, end: endTime };
+    const existingDayIndex = schedule.findIndex(d => d.day === selectedDay);
+
+    if (existingDayIndex >= 0) {
+      // Agregar al día existente
+      const updatedSchedule = [...schedule];
+      updatedSchedule[existingDayIndex].timeSlots.push(newTimeSlot);
+      onChange(updatedSchedule);
+    } else {
+      // Crear nuevo día
+      const newDaySchedule: DaySchedule = {
+        day: selectedDay,
+        timeSlots: [newTimeSlot]
+      };
+      onChange([...schedule, newDaySchedule]);
+    }
+
+    // Limpiar formulario
+    setStartTime('');
+    setEndTime('');
+  };
+
+  const removeTimeSlot = (dayIndex: number, slotIndex: number) => {
+    const updatedSchedule = [...schedule];
+    updatedSchedule[dayIndex].timeSlots.splice(slotIndex, 1);
+    
+    // Si no quedan horarios, remover el día
+    if (updatedSchedule[dayIndex].timeSlots.length === 0) {
+      updatedSchedule.splice(dayIndex, 1);
+    }
+    
+    onChange(updatedSchedule);
+  };
+
+  const formatTime = (time: string) => {
+    return `${time}`;
+  };
+
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom sx={{ color: '#1976d2', mb: 3 }}>
+        ¿Entre qué rango de horarios tienes disponibilidad para estudiar?
+      </Typography>
+
+      {/* Formulario para agregar horarios */}
+      <Paper sx={{ p: 3, mb: 3, backgroundColor: '#f8f9fa' }}>
+        <Typography variant="subtitle1" gutterBottom sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Schedule color="primary" />
+          Agregar horario de estudio
+        </Typography>
+        
+        <Stack spacing={2}>
+          <FormControl fullWidth>
+            <InputLabel>Día de la semana</InputLabel>
+            <Select
+              value={selectedDay}
+              onChange={(e) => setSelectedDay(e.target.value)}
+              label="Día de la semana"
+            >
+              {daysOfWeek.map((day) => (
+                <MenuItem key={day.value} value={day.value}>
+                  {day.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <FormControl fullWidth>
+              <InputLabel>Hora inicio</InputLabel>
+              <Select
+                value={startTime}
+                onChange={(e) => setStartTime(e.target.value)}
+                label="Hora inicio"
+              >
+                {timeSlots.map((time) => (
+                  <MenuItem key={time} value={time}>
+                    {time}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            <FormControl fullWidth>
+              <InputLabel>Hora fin</InputLabel>
+              <Select
+                value={endTime}
+                onChange={(e) => setEndTime(e.target.value)}
+                label="Hora fin"
+              >
+                {timeSlots.map((time) => (
+                  <MenuItem key={time} value={time}>
+                    {time}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Stack>
+
+          <Button
+            variant="contained"
+            startIcon={<Add />}
+            onClick={addTimeSlot}
+            disabled={!selectedDay || !startTime || !endTime}
+            sx={{
+              alignSelf: 'flex-start',
+              borderRadius: 2,
+              background: 'linear-gradient(135deg, #1976d2 0%, #1565c0 100%)',
+            }}
+          >
+            Agregar Horario
+          </Button>
+        </Stack>
+      </Paper>
+
+      {/* Vista del calendario semanal */}
+      <Box sx={{ mb: 2 }}>
+        <Typography variant="subtitle1" gutterBottom sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <AccessTime color="primary" />
+          Tu horario de estudio semanal
+        </Typography>
+        
+        {schedule.length === 0 ? (
+          <Paper sx={{ p: 3, textAlign: 'center', backgroundColor: '#fafafa' }}>
+            <Typography variant="body2" color="text.secondary">
+              No has agregado horarios aún. Selecciona los días y horas que tienes disponibles para estudiar.
+            </Typography>
+          </Paper>
+        ) : (
+          <Box sx={{ 
+            display: 'grid', 
+            gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', 
+            gap: 2,
+            '@media (max-width: 600px)': {
+              gridTemplateColumns: '1fr'
+            }
+          }}>
+            {daysOfWeek.map((dayOfWeek) => {
+              const daySchedule = schedule.find(d => d.day === dayOfWeek.value);
+              return (
+                <Box key={dayOfWeek.value}>
+                  <Card sx={{ 
+                    height: '100%',
+                    backgroundColor: daySchedule ? '#e3f2fd' : '#f5f5f5',
+                    border: daySchedule ? '2px solid #1976d2' : '1px solid #e0e0e0'
+                  }}>
+                    <CardContent>
+                      <Typography variant="h6" gutterBottom sx={{ 
+                        color: daySchedule ? '#1976d2' : '#666',
+                        textAlign: 'center',
+                        fontWeight: 'bold'
+                      }}>
+                        {dayOfWeek.label}
+                      </Typography>
+                      
+                      {daySchedule ? (
+                        <Stack spacing={1}>
+                          {daySchedule.timeSlots.map((slot, slotIndex) => {
+                            const dayIndex = schedule.findIndex(d => d.day === dayOfWeek.value);
+                            return (
+                              <Chip
+                                key={slotIndex}
+                                label={`${formatTime(slot.start)} - ${formatTime(slot.end)}`}
+                                variant="filled"
+                                color="primary"
+                                size="small"
+                                onDelete={() => removeTimeSlot(dayIndex, slotIndex)}
+                                deleteIcon={<Delete />}
+                                sx={{ 
+                                  fontSize: '0.75rem',
+                                  '& .MuiChip-deleteIcon': {
+                                    fontSize: '16px'
+                                  }
+                                }}
+                              />
+                            );
+                          })}
+                        </Stack>
+                      ) : (
+                        <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center', fontStyle: 'italic' }}>
+                          Sin horarios
+                        </Typography>
+                      )}
+                    </CardContent>
+                  </Card>
+                </Box>
+              );
+            })}
+          </Box>
+        )}
+      </Box>
+
+      {error && (
+        <Typography variant="caption" color="error" sx={{ mt: 1, display: 'block' }}>
+          Por favor agrega al menos un horario de estudio
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/src/components/modals/welcome/StudyResourcesStep.tsx
+++ b/src/components/modals/welcome/StudyResourcesStep.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  TextField,
+  InputAdornment,
+  Stack
+} from '@mui/material';
+import { School, YouTube } from '@mui/icons-material';
+
+interface StudyResourcesStepProps {
+  estudio: string;
+  youtubeUrl: string;
+  onStudyChange: (value: string) => void;
+  onYouTubeChange: (value: string) => void;
+  studyError: boolean;
+  youtubeError: boolean;
+}
+
+export default function StudyResourcesStep({ 
+  estudio, 
+  youtubeUrl, 
+  onStudyChange, 
+  onYouTubeChange, 
+  studyError, 
+  youtubeError 
+}: StudyResourcesStepProps) {
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom sx={{ color: '#1976d2', mb: 3 }}>
+        ¿Qué te gustaría estudiar y qué recursos tienes?
+      </Typography>
+      
+      <Stack spacing={3}>
+        <TextField
+          fullWidth
+          label="¿Qué quieres estudiar?"
+          value={estudio}
+          onChange={(e) => onStudyChange(e.target.value)}
+          error={studyError}
+          helperText={studyError ? 'Por favor describe qué quieres estudiar' : 'Ej: Matemáticas, Programación, Idiomas, etc.'}
+          placeholder="Describe tu área de estudio"
+          multiline
+          rows={3}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <School color="action" />
+              </InputAdornment>
+            ),
+          }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              borderRadius: 2,
+            },
+          }}
+        />
+
+        <TextField
+          fullWidth
+          label="URL de YouTube (opcional)"
+          value={youtubeUrl}
+          onChange={(e) => onYouTubeChange(e.target.value)}
+          error={youtubeError}
+          helperText={
+            youtubeError 
+              ? 'Por favor ingresa una URL válida de YouTube' 
+              : 'Si tienes algún video o canal de YouTube que quieras usar como recurso'
+          }
+          placeholder="https://www.youtube.com/..."
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <YouTube color="action" />
+              </InputAdornment>
+            ),
+          }}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              borderRadius: 2,
+            },
+          }}
+        />
+      </Stack>
+    </Box>
+  );
+}

--- a/src/components/modals/welcome/StudyStep.tsx
+++ b/src/components/modals/welcome/StudyStep.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  TextField,
+  InputAdornment
+} from '@mui/material';
+import { School } from '@mui/icons-material';
+
+interface StudyStepProps {
+  estudio: string;
+  onChange: (value: string) => void;
+  error: boolean;
+}
+
+export default function StudyStep({ estudio, onChange, error }: StudyStepProps) {
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom sx={{ color: '#1976d2', mb: 3 }}>
+        ¿Qué te gustaría estudiar?
+      </Typography>
+      <TextField
+        fullWidth
+        label="¿Qué quieres estudiar?"
+        value={estudio}
+        onChange={(e) => onChange(e.target.value)}
+        error={error}
+        helperText={error ? 'Por favor describe qué quieres estudiar' : 'Ej: Matemáticas, Programación, Idiomas, etc.'}
+        placeholder="Describe tu área de estudio"
+        multiline
+        rows={3}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <School color="action" />
+            </InputAdornment>
+          ),
+        }}
+        sx={{
+          '& .MuiOutlinedInput-root': {
+            borderRadius: 2,
+          },
+        }}
+      />
+    </Box>
+  );
+}

--- a/src/components/modals/welcome/TimeStep.tsx
+++ b/src/components/modals/welcome/TimeStep.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  InputAdornment
+} from '@mui/material';
+import { AccessTime } from '@mui/icons-material';
+// Deprecated component - replaced by ScheduleStep
+const timeOptions = [
+  { value: "1-2h", label: "1-2 horas al día" },
+  { value: "2-4h", label: "2-4 horas al día" },
+  { value: "4-6h", label: "4-6 horas al día" },
+];
+
+interface TimeStepProps {
+  tiempoDisponible: string;
+  onChange: (value: string) => void;
+  error: boolean;
+}
+
+export default function TimeStep({ tiempoDisponible, onChange, error }: TimeStepProps) {
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom sx={{ color: '#1976d2', mb: 3 }}>
+        ¿Cuánto tiempo tienes disponible para estudiar?
+      </Typography>
+      <FormControl fullWidth error={error}>
+        <InputLabel>Tiempo disponible</InputLabel>
+        <Select
+          value={tiempoDisponible}
+          onChange={(e) => onChange(e.target.value)}
+          label="Tiempo disponible"
+          startAdornment={
+            <InputAdornment position="start">
+              <AccessTime color="action" />
+            </InputAdornment>
+          }
+          sx={{
+            borderRadius: 2,
+          }}
+        >
+          {timeOptions.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </Select>
+        {error && (
+          <Typography variant="caption" color="error" sx={{ mt: 1 }}>
+            Por favor selecciona tu disponibilidad de tiempo
+          </Typography>
+        )}
+      </FormControl>
+    </Box>
+  );
+}

--- a/src/components/modals/welcome/WelcomeModal.tsx
+++ b/src/components/modals/welcome/WelcomeModal.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+  Stepper,
+  Step,
+  StepLabel,
+} from '@mui/material';
+import NameStep from './NameStep';
+import StudyResourcesStep from './StudyResourcesStep';
+import ScheduleStep from './ScheduleStep';
+import { WelcomeFormData, steps, isValidYouTubeUrl } from './types';
+
+interface WelcomeModalProps {
+  open: boolean;
+  onClose: () => void;
+  onComplete: (data: WelcomeFormData) => void;
+}
+
+export default function WelcomeModal({ open, onClose, onComplete }: WelcomeModalProps) {
+  const [activeStep, setActiveStep] = useState(0);
+  const [formData, setFormData] = useState<WelcomeFormData>(() => {
+    // Cargar datos persistentes del localStorage si existen
+    if (typeof window !== 'undefined') {
+      const savedData = localStorage.getItem('welcomeFormData');
+      if (savedData) {
+        return JSON.parse(savedData);
+      }
+    }
+    return {
+      nombre: '',
+      estudio: '',
+      youtubeUrl: '',
+      tiempoDisponible: []
+    };
+  });
+  const [errors, setErrors] = useState({
+    nombre: false,
+    estudio: false,
+    youtubeUrl: false,
+    tiempoDisponible: false
+  });
+
+  // Persistencia: guardar datos en localStorage cada vez que cambien
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('welcomeFormData', JSON.stringify(formData));
+    }
+  }, [formData]);
+
+  // Limpiar formulario
+  const clearForm = () => {
+    const initialFormData = {
+      nombre: '',
+      estudio: '',
+      youtubeUrl: '',
+      tiempoDisponible: []
+    };
+    setFormData(initialFormData);
+    setActiveStep(0);
+    setErrors({
+      nombre: false,
+      estudio: false,
+      youtubeUrl: false,
+      tiempoDisponible: false
+    });
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('welcomeFormData');
+    }
+  };
+
+  // Manejar cancelar: cerrar modal y limpiar formulario
+  const handleCancel = () => {
+    clearForm();
+    onClose();
+  };
+
+  const handleNext = () => {
+    if (validateCurrentStep()) {
+      if (activeStep === steps.length - 1) {
+        // Limpiar localStorage al completar exitosamente
+        if (typeof window !== 'undefined') {
+          localStorage.removeItem('welcomeFormData');
+        }
+        onComplete(formData);
+      } else {
+        setActiveStep((prev) => prev + 1);
+      }
+    }
+  };
+
+  const handleBack = () => {
+    setActiveStep((prev) => prev - 1);
+  };
+
+  const validateCurrentStep = (): boolean => {
+    const newErrors = { ...errors };
+    let isValid = true;
+
+    switch (activeStep) {
+      case 0: // Nombre
+        if (!formData.nombre.trim()) {
+          newErrors.nombre = true;
+          isValid = false;
+        } else {
+          newErrors.nombre = false;
+        }
+        break;
+      case 1: // Estudio y YouTube
+        if (!formData.estudio.trim()) {
+          newErrors.estudio = true;
+          isValid = false;
+        } else {
+          newErrors.estudio = false;
+        }
+        // YouTube es opcional, solo validar si tiene contenido
+        if (formData.youtubeUrl.trim() && !isValidYouTubeUrl(formData.youtubeUrl)) {
+          newErrors.youtubeUrl = true;
+          isValid = false;
+        } else {
+          newErrors.youtubeUrl = false;
+        }
+        break;
+      case 2: // Horarios
+        if (!formData.tiempoDisponible || formData.tiempoDisponible.length === 0) {
+          newErrors.tiempoDisponible = true;
+          isValid = false;
+        } else {
+          newErrors.tiempoDisponible = false;
+        }
+        break;
+    }
+
+    setErrors(newErrors);
+    return isValid;
+  };
+
+  const handleStringFieldChange = (field: 'nombre' | 'estudio' | 'youtubeUrl') => (value: string) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: value
+    }));
+    // Limpiar error al escribir
+    if (errors[field]) {
+      setErrors(prev => ({ ...prev, [field]: false }));
+    }
+  };
+
+  const handleScheduleChange = (schedule: WelcomeFormData['tiempoDisponible']) => {
+    setFormData(prev => ({
+      ...prev,
+      tiempoDisponible: schedule
+    }));
+    // Limpiar error al cambiar
+    if (errors.tiempoDisponible) {
+      setErrors(prev => ({ ...prev, tiempoDisponible: false }));
+    }
+  };
+
+  const renderStepContent = () => {
+    switch (activeStep) {
+      case 0:
+        return (
+          <NameStep
+            nombre={formData.nombre}
+            onChange={handleStringFieldChange('nombre')}
+            error={errors.nombre}
+          />
+        );
+      case 1:
+        return (
+          <StudyResourcesStep
+            estudio={formData.estudio}
+            youtubeUrl={formData.youtubeUrl}
+            onStudyChange={handleStringFieldChange('estudio')}
+            onYouTubeChange={handleStringFieldChange('youtubeUrl')}
+            studyError={errors.estudio}
+            youtubeError={errors.youtubeUrl}
+          />
+        );
+      case 2:
+        return (
+          <ScheduleStep
+            schedule={formData.tiempoDisponible}
+            onChange={handleScheduleChange}
+            error={errors.tiempoDisponible}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={() => {}} // Desactivar cierre al hacer clic fuera
+      disableEscapeKeyDown // Desactivar cierre con tecla Escape
+      maxWidth="md"
+      fullWidth
+      PaperProps={{
+        sx: {
+          borderRadius: 3,
+          minHeight: '500px'
+        }
+      }}
+    >
+      <DialogTitle sx={{ pb: 1 }}>
+        <Typography variant="h4" component="div" sx={{ color: '#1976d2', fontWeight: 'bold', mb: 2 }}>
+          ¡Bienvenido a PrioSync! 🎓
+        </Typography>
+        <Stepper activeStep={activeStep} alternativeLabel>
+          {steps.map((label) => (
+            <Step key={label}>
+              <StepLabel>{label}</StepLabel>
+            </Step>
+          ))}
+        </Stepper>
+      </DialogTitle>
+
+      <DialogContent sx={{ pt: 3, pb: 2 }}>
+        {renderStepContent()}
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 3 }}>
+        <Button
+          onClick={handleCancel}
+          variant="outlined"
+          sx={{ borderRadius: 2 }}
+        >
+          Cancelar
+        </Button>
+        
+        {activeStep > 0 && (
+          <Button
+            onClick={handleBack}
+            variant="outlined"
+            sx={{ borderRadius: 2, ml: 1 }}
+          >
+            Atrás
+          </Button>
+        )}
+        
+        <Button
+          onClick={handleNext}
+          variant="contained"
+          sx={{
+            borderRadius: 2,
+            ml: 1,
+            background: 'linear-gradient(135deg, #1976d2 0%, #1565c0 100%)',
+          }}
+        >
+          {activeStep === steps.length - 1 ? 'Continuar' : 'Siguiente'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/modals/welcome/YouTubeStep.tsx
+++ b/src/components/modals/welcome/YouTubeStep.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {
+  Box,
+  Typography,
+  TextField,
+  InputAdornment
+} from '@mui/material';
+import { YouTube } from '@mui/icons-material';
+
+interface YouTubeStepProps {
+  youtubeUrl: string;
+  onChange: (value: string) => void;
+  error: boolean;
+}
+
+export default function YouTubeStep({ youtubeUrl, onChange, error }: YouTubeStepProps) {
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom sx={{ color: '#1976d2', mb: 3 }}>
+        ¿Tienes algún recurso de YouTube que te gustaría usar?
+      </Typography>
+      <TextField
+        fullWidth
+        label="URL de YouTube"
+        value={youtubeUrl}
+        onChange={(e) => onChange(e.target.value)}
+        error={error}
+        helperText={
+          error 
+            ? 'Por favor ingresa una URL válida de YouTube' 
+            : 'Ej: https://www.youtube.com/watch?v=...'
+        }
+        placeholder="https://www.youtube.com/..."
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <YouTube color="action" />
+            </InputAdornment>
+          ),
+        }}
+        sx={{
+          '& .MuiOutlinedInput-root': {
+            borderRadius: 2,
+          },
+        }}
+      />
+    </Box>
+  );
+}

--- a/src/components/modals/welcome/types.ts
+++ b/src/components/modals/welcome/types.ts
@@ -1,0 +1,58 @@
+export interface TimeSlot {
+  start: string;
+  end: string;
+}
+
+export interface DaySchedule {
+  day: string;
+  timeSlots: TimeSlot[];
+}
+
+export interface WelcomeFormData {
+  nombre: string;
+  estudio: string;
+  youtubeUrl: string;
+  tiempoDisponible: DaySchedule[];
+}
+
+export const daysOfWeek = [
+  { value: "lunes", label: "Lunes" },
+  { value: "martes", label: "Martes" },
+  { value: "miércoles", label: "Miércoles" },
+  { value: "jueves", label: "Jueves" },
+  { value: "viernes", label: "Viernes" },
+  { value: "sábado", label: "Sábado" },
+  { value: "domingo", label: "Domingo" },
+];
+
+export const timeSlots = [
+  "06:00",
+  "07:00",
+  "08:00",
+  "09:00",
+  "10:00",
+  "11:00",
+  "12:00",
+  "13:00",
+  "14:00",
+  "15:00",
+  "16:00",
+  "17:00",
+  "18:00",
+  "19:00",
+  "20:00",
+  "21:00",
+  "22:00",
+  "23:00",
+];
+
+export const steps = [
+  "Información Personal",
+  "Objetivos y Recursos",
+  "Horarios Disponibles",
+];
+
+export const isValidYouTubeUrl = (url: string): boolean => {
+  const youtubeRegex = /^(https?:\/\/)?(www\.)?(youtube\.com|youtu\.be)\/.+/;
+  return youtubeRegex.test(url);
+};


### PR DESCRIPTION
- Agregar landing page con hero section y componentes principales
- Implementar modal de bienvenida con 3 pasos (nombre, recursos de estudio, horarios disponibles)
- Crear calendario semanal para selección de horarios de estudio
- Implementar modal de registro con validación de campos chilenos (teléfono +56)
- Agregar persistencia de datos con localStorage para ambos modals
- Implementar limpieza automática de formularios al cancelar o completar
- Agregar protección contra cierre accidental (clic fuera, tecla Escape)
- Usar layout de columnas (CSS Grid) para calendario de días de la semana
- Aplicar TypeScript estricto sin tipos 'any'
- Asegurar HTML semántico correcto (sin elementos h2 anidados)